### PR TITLE
Updated Hazelcast libraries to the latest version.

### DIFF
--- a/headlands-ui/pom.xml
+++ b/headlands-ui/pom.xml
@@ -31,7 +31,7 @@ limitations under the License.
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast-all</artifactId>
-            <version>3.3.3</version>
+            <version>3.4.1</version>
         </dependency>
         <dependency>
             <groupId>javax.cache</groupId>

--- a/headlands/pom.xml
+++ b/headlands/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast-all</artifactId>
-            <version>3.3.3</version>
+            <version>3.4.1</version>
         </dependency>
         <dependency>
             <groupId>javax.cache</groupId>


### PR DESCRIPTION
JCache Support is Hazelcast 3.4 has been massively improved.
